### PR TITLE
Update to gwt-dom 1.0.0-RC2

### DIFF
--- a/gwt-aria-j2cl-tests/pom.xml
+++ b/gwt-aria-j2cl-tests/pom.xml
@@ -3,99 +3,80 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 <modelVersion>4.0.0</modelVersion>
 
-<parent>
-  <groupId>org.gwtproject.aria</groupId>
-  <artifactId>gwt-aria-parent</artifactId>
-  <version>dev</version>
-</parent>
-<artifactId>gwt-aria-j2cl-tests</artifactId>
-<version>${revision}</version>
-
-<name>GWT Aria - J2CL Tests</name>
-<description>Test cases for the J2Cl tests</description>
-<url>https://github.com/gwtproject/gwt-aria</url>
-
-<properties>
-  <maven.j2cl.plugin>0.16-SNAPSHOT</maven.j2cl.plugin>
-
-  <!-- CI -->
-  <vertispan.j2cl.repo.url>https://repo.vertispan.com/j2cl/</vertispan.j2cl.repo.url>
-
-  <j2cl.version>0.8-SNAPSHOT</j2cl.version>
-</properties>
-
-<dependencies>
-  <!-- test dependencies -->
-  <dependency>
-    <groupId>com.vertispan.j2cl</groupId>
-    <artifactId>junit-annotations</artifactId>
-    <version>${j2cl.version}</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>com.vertispan.j2cl</groupId>
-    <artifactId>gwttestcase-emul</artifactId>
-    <version>${j2cl.version}</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>com.vertispan.j2cl</groupId>
-    <artifactId>junit-emul</artifactId>
-    <version>${j2cl.version}</version>
-    <scope>test</scope>
-  </dependency>
-
-  <dependency>
+  <parent>
     <groupId>org.gwtproject.aria</groupId>
-    <artifactId>gwt-aria</artifactId>
-    <version>${revision}</version>
-    <scope>test</scope>
-  </dependency>
-</dependencies>
+    <artifactId>gwt-aria-parent</artifactId>
+    <version>dev</version>
+  </parent>
+  <artifactId>gwt-aria-j2cl-tests</artifactId>
+  <version>${revision}</version>
 
-<build>
-  <plugins>
-    <plugin>
+  <name>GWT Aria - J2CL Tests</name>
+  <description>Test cases for the J2Cl tests</description>
+  <url>https://github.com/gwtproject/gwt-aria</url>
+
+  <properties>
+    <maven.j2cl.plugin>0.19</maven.j2cl.plugin>
+
+    <j2cl.version>0.10.0-3c97afeac</j2cl.version>
+  </properties>
+
+  <dependencies>
+    <!-- test dependencies -->
+    <dependency>
       <groupId>com.vertispan.j2cl</groupId>
-      <artifactId>j2cl-maven-plugin</artifactId>
-      <version>${maven.j2cl.plugin}</version>
-      <configuration>
-        <compilationLevel>ADVANCED</compilationLevel>
-      </configuration>
-      <executions>
-        <execution>
-          <id>j2cl-test</id>
-          <phase>test</phase>
-          <goals>
-            <goal>test</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-surefire-plugin</artifactId>
-      <version>${maven.surfire.plugin}</version>
-      <configuration>
-        <skipTests>true</skipTests>
-      </configuration>
-    </plugin>
-  </plugins>
-</build>
+      <artifactId>junit-annotations</artifactId>
+      <version>${j2cl.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vertispan.j2cl</groupId>
+      <artifactId>gwttestcase-emul</artifactId>
+      <version>${j2cl.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.vertispan.j2cl</groupId>
+      <artifactId>junit-emul</artifactId>
+      <version>${j2cl.version}</version>
+      <scope>test</scope>
+    </dependency>
 
-<repositories>
-  <repository>
-    <id>vertispan-snapshots</id>
-    <name>Vertispan hosted artifacts-releases</name>
-    <url>${vertispan.j2cl.repo.url}</url>
-  </repository>
-</repositories>
+    <dependency>
+      <groupId>org.gwtproject.aria</groupId>
+      <artifactId>gwt-aria</artifactId>
+      <version>${revision}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-<pluginRepositories>
-  <pluginRepository>
-    <id>vertispan-releases</id>
-    <name>Vertispan hosted artifacts-releases</name>
-    <url>${vertispan.j2cl.repo.url}</url>
-  </pluginRepository>
-</pluginRepositories>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.vertispan.j2cl</groupId>
+        <artifactId>j2cl-maven-plugin</artifactId>
+        <version>${maven.j2cl.plugin}</version>
+        <configuration>
+          <compilationLevel>ADVANCED</compilationLevel>
+        </configuration>
+        <executions>
+          <execution>
+            <id>j2cl-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven.surfire.plugin}</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/gwt-aria/pom.xml
+++ b/gwt-aria/pom.xml
@@ -50,7 +50,7 @@
     <maven.source.plugin>3.2.1</maven.source.plugin>
 
     <elemental2.version>1.1.0</elemental2.version>
-    <gwt-dom.version>1.0.0-RC1</gwt-dom.version>
+    <gwt-dom.version>1.0.0-RC2</gwt-dom.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This fixes compatibility with j2cl. This merge also updates to the
latest j2cl-maven-plugin version, and removes unnecessary repository
tags, now that we're using a release build.

Also cleaned up whitespace in the j2cl tests project.